### PR TITLE
fix: Atualiza a configuracao para a nova versao do zmk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,4 +3,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+.idea/
+.zmk
+zmk/

--- a/config/west.yml
+++ b/config/west.yml
@@ -2,6 +2,7 @@
 manifest:
   defaults:
     remote: urob
+    revision: v0.3
 
   remotes:
     - name: zmkfirmware
@@ -30,7 +31,7 @@ manifest:
     # Zephyr with a path other than `zephyr` (as in `going-modular`).
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3
       import: app/west.yml
 
   self:

--- a/config/west.yml
+++ b/config/west.yml
@@ -15,13 +15,10 @@ manifest:
     
   projects:
     - name: zmk-helpers
-      revision: main
       path: modules/helpers
     - name: zmk-auto-layer
-      revision: main
       path: modules/auto-layer
     - name: zmk-tri-state
-      revision: main
       path: modules/tri-state
     # include dongle-display
     - name: zmk-dongle-display


### PR DESCRIPTION
This pull request updates the repository to use the v0.3 release of ZMK and its related modules instead of tracking the `main` branch. This helps ensure a more stable and predictable build by locking dependencies to a specific version.

Dependency version updates:

* Updated the `zmk` project in `config/west.yml` to use the `v0.3` release instead of the `main` branch.
* Set the global manifest revision to `v0.3` in `config/west.yml` for consistent dependency versions.
* Removed explicit `main` branch revisions for `zmk-helpers`, `zmk-auto-layer`, and `zmk-tri-state` modules in `config/west.yml`, so they now inherit the global revision (`v0.3`).

Build workflow update:

* Changed the GitHub Actions workflow in `.github/workflows/build.yml` to use the `build-user-config.yml` workflow from the `v0.3` branch of `zmkfirmware/zmk` instead of `main`.